### PR TITLE
Working proxy release.

### DIFF
--- a/wrapper/proxy/base.py
+++ b/wrapper/proxy/base.py
@@ -117,7 +117,7 @@ class Proxy:
         :return: the matching client
         """
         for client in self.clients:
-            if client.serverUUID.string == str(uuid):
+            if client.serverUuid.string == str(uuid):
                 self.uuidTranslate[uuid] = client.uuid.string
                 return client
         return False # no client

--- a/wrapper/proxy/client.py
+++ b/wrapper/proxy/client.py
@@ -99,6 +99,10 @@ class Client:
         for i in range(45):
             self.inventory[i] = None
 
+    @property
+    def version(self):
+        return self.clientversion
+
     def connect_to_server(self, ip=None, port=None):
         """
         Args:
@@ -626,7 +630,7 @@ class Client:
                 t_keepalives.daemon = True
                 t_keepalives.start()
 
-                #self.connect_to_server()
+                self.connect_to_server()
 
                 self.log.info("%s logged in (UUID: %s | IP: %s)", self.username, self.uuid.string, self.addr[0])
                 return False
@@ -727,7 +731,7 @@ class Client:
                 # send packet if server available and parsing passed.
                 if self.parse(pkid) and self.server:
                     if self.server.state == 3:
-                        self.server.sendRaw(original)
+                        self.server.packet.sendRaw(original)
         except Exception as ex:
             self.log.exception("Error in the [Client] -> [Server] handle (%s):", ex)
 

--- a/wrapper/proxy/client.py
+++ b/wrapper/proxy/client.py
@@ -214,7 +214,7 @@ class Client:
     def parse(self, pkid):  # server - bound parse ("Client" class connection)
         if self.state == ClientState.PLAY:
             # TODO - elif these packet parsers
-            if pkid == self.pktCB.KEEP_ALIVE:
+            if pkid == self.pktSB.KEEP_ALIVE:
                 if self.serverversion < mcpacket.PROTOCOL_1_8START:
                     data = self.packet.read("int:payload")
                 else:  # self.version >= mcpacket.PROTOCOL_1_8START:

--- a/wrapper/proxy/server.py
+++ b/wrapper/proxy/server.py
@@ -76,7 +76,7 @@ class Server:
             self.client.isLocal = False
 
         self.packet = Packet(self.server_socket, self)
-        self.packet.version = self.client.version
+        self.packet.version = self.client.clientversion
 
         t = threading.Thread(target=self.flush, args=())
         t.daemon = True
@@ -88,7 +88,7 @@ class Server:
         self.packet = None
         try:
             self.server_socket.close()
-        except Exception as e:
+        except OSError:
             pass
 
         if not self.client.isLocal and kill_client:  # Ben's cross-server hack
@@ -565,7 +565,7 @@ class Server:
                     self.close()
                     break
                 if self.parse(pkid) and self.client:
-                    self.client.sendRaw(original)
+                    self.client.packet.sendRaw(original)
         except Exception as e2:
             self.log.exception("Error in the [SERVER] -> [CLIENT] handle (%s):", e2)
             self.close()


### PR DESCRIPTION
- server.py and client.py both operate as intended.
- wrapper now handles all keep alives.  With further work, a client connection can be maintained for various purposes (server restart,etc) when no server is present.
- IMPORTANT: packet send methods, which were once simply client.send() or server.send() MUST NOW use client. __packet.__ send()  This may break non-api conforming plugins using packet .send() methods. removing the `self.send = self.client.send` type statements were done to clean the code a little and improve readability.
