### PR TITLE
Fix #78

### DIFF
--- a/build/CHANGELOG.DEV.md
+++ b/build/CHANGELOG.DEV.md
@@ -1,3 +1,9 @@
+
+- Separate path for server supported.  Wrapper folder remains unchanged and by default, the server uses the wrapper folder too, as it always has.
+    - there is no need to modify the start command in wrapper.properties.json; wrapper automatically prefixes the server path.
+    - getStorage() method still takes the second (world=True) argument to put a storage object in the world (server) folder, so data can stay server-specific.
+    - This also means you should not attempt to run a server as wrapper startup arguments (like `python /home/surest/MyServer/wrapper java -jar minecraft_server.1.9.2.jar nogui`).  Wrapper needs to parse the server command from wrapper.properties.json.
+
 Build #118 [0.8.4]
 - Fixed serious bug fix for wrapper.getusernamebyuuid() that will prevent new players from joining.
 - Refactored config.py to use pure json (updates wrapper.properties to wrapper.properties.json).

--- a/wrapper/api/base.py
+++ b/wrapper/api/base.py
@@ -76,6 +76,8 @@ class API:
         self.name = name
         self.minecraft = Minecraft(wrapper)
         self.javaserver = wrapper.javaserver
+        self.config = wrapper.config
+        self.serverpath = self.config["General"]["server-directory"]
         self.internal = internal
         if someid is None:
             self.id = name
@@ -178,7 +180,8 @@ class API:
         plugin will need to remember across reboots.
         Setting world=True will store the data inside the current world folder, for world-specific data.  
         """
-        if not world:
-            return Storage(name, root=".wrapper-data/plugins/%s" % self.id)
+        if world:
+            return Storage(name, root="%s/%s/plugins/%s" %
+                                      (self.serverpath, self.minecraft.getWorldName(), self.id))
         else:
-            return Storage(name, root="%s/plugins/%s" % (self.minecraft.getWorldName(), self.id))
+            return Storage(name, root="wrapper-data/plugins/%s" % self.id)

--- a/wrapper/api/minecraft.py
+++ b/wrapper/api/minecraft.py
@@ -20,6 +20,7 @@ class Minecraft:
         self.proxy = wrapper.proxy
         self.log = wrapper.log
         self._encoding = wrapper.config["General"]["encoding"]
+        self.serverpath = wrapper.config["General"]["server-directory"]
 
         blockdata = Items()
         self.blocks = blockdata.itemslist
@@ -318,7 +319,7 @@ class Minecraft:
             worldname = self.wrapper.javaserver.worldName
         if not worldname:
             raise Exception("Server Uninitiated")
-        f = NBTFile("%s/level.dat" % worldname, "rb")
+        f = NBTFile("%s/%s/level.dat" % (self.serverpath, worldname), "rb")
         return f["Data"]
 
     def getSpawnPoint(self):

--- a/wrapper/api/minecraft.py
+++ b/wrapper/api/minecraft.py
@@ -100,7 +100,8 @@ class Minecraft:
     def getAllPlayers(self):
         """
 
-        Returns: Returns a dict containing all players ever connected to the server
+        Returns: Returns a dict containing the uuids and associated login data of all
+        players ever connected to the server.
 
         """
         if self.wrapper.isonlinemode():
@@ -160,7 +161,7 @@ class Minecraft:
         pass
         # TODO a good idea
 
-    def getOfflineUUID(self,name):
+    def getOfflineUUID(self, name):
         """
         :param name: gets UUID object based on "OfflinePlayer:<playername>"
         :return: a MCUUID object based on the name

--- a/wrapper/api/player.py
+++ b/wrapper/api/player.py
@@ -51,6 +51,8 @@ class Player:
         self.javaserver = wrapper.javaserver
         self.permissions = wrapper.permissions
         self.log = wrapper.log
+        self._encoding = wrapper.config["General"]["encoding"]
+        self.serverpath = wrapper.config["General"]["server-directory"]
 
         self.username = username
         self.loggedIn = time.time()
@@ -152,11 +154,11 @@ class Player:
         """
         ops = False
         if self.javaserver.protocolVersion > mcpacket.PROTOCOL_1_7:  # 1.7.6 or greater use ops.json
-            ops = getjsonfile("ops")
+            ops = getjsonfile("ops", self.serverpath, encodedas=self._encoding)
         if not ops:
             # try for an old "ops.txt" file instead.
             ops = {}
-            opstext = getfileaslines("ops.txt")
+            opstext = getfileaslines("ops.txt", self.serverpath)
             if not opstext:
                 return False
             for x in range(len(opstext)):

--- a/wrapper/core/commands.py
+++ b/wrapper/core/commands.py
@@ -15,6 +15,7 @@ class Commands:
     def __init__(self, wrapper):
         self.wrapper = wrapper
         self.log = wrapper.log
+        self.config = wrapper.config
 
         self.commands = {}
 

--- a/wrapper/core/config.py
+++ b/wrapper/core/config.py
@@ -7,6 +7,7 @@ from utils.helpers import getjsonfile, putjsonfile
 
 """[General]
 server-name = Minecraft Server
+server-directory = "."
 command = java -jar minecraft_server.1.9.2.jar nogui
 auto-restart = True
 auto-update-wrapper = False
@@ -156,10 +157,10 @@ class Config:
             os.remove("wrapper.properties")
 
         if not os.path.exists("wrapper.properties.json"):
-            putjsonfile(NEWCONFIG, "wrapper.properties", sort=True)
+            putjsonfile(NEWCONFIG, "wrapper.properties", sort=True, encodedas="UTF-8")
             self.exit = True
 
-        self.config = getjsonfile("wrapper.properties")
+        self.config = getjsonfile("wrapper.properties", encodedas="UTF-8")  # the only data file that must be UTF-8
 
         changesmade = False
         for section in NEWCONFIG:
@@ -182,4 +183,4 @@ class Config:
             sys.exit()
 
     def save(self):
-        putjsonfile(self.config, "wrapper.properties", sort=True)
+        putjsonfile(self.config, "wrapper.properties", sort=True, encodedas="UTF-8")

--- a/wrapper/core/config.py
+++ b/wrapper/core/config.py
@@ -160,7 +160,13 @@ class Config:
             putjsonfile(NEWCONFIG, "wrapper.properties", sort=True, encodedas="UTF-8")
             self.exit = True
 
-        self.config = getjsonfile("wrapper.properties", encodedas="UTF-8")  # the only data file that must be UTF-8
+        self.config = getjsonfile("wrapper.properties")  # the only data file that must be UTF-8
+        if self.config is None:
+            self.log.error("I think you messed up the Json formatting of your "
+                           "wrapper.properties.json file. "
+                           "Take your file and have it checked at: \n"
+                           "http://jsonlint.com/")
+            self.exit = True
 
         changesmade = False
         for section in NEWCONFIG:

--- a/wrapper/core/mcserver.py
+++ b/wrapper/core/mcserver.py
@@ -13,7 +13,6 @@ from core.exceptions import UnsupportedOSException, InvalidServerStateError
 
 import time
 import threading
-import random
 import subprocess
 import os
 import json
@@ -34,11 +33,22 @@ except ImportError:
 # noinspection PyBroadException,PyUnusedLocal
 class MCServer:
 
-    def __init__(self, args, log, config, wrapper):
-        self.log = log
-        self.config = config
+    def __init__(self, wrapper):
+        self.log = wrapper.log
+        self.config = wrapper.config
+        self.encoding = self.config["General"]["encoding"]
+        self.serverpath = self.config["General"]["server-directory"]
         self.wrapper = wrapper
-        self.args = args
+        self.args = self.config["General"]["command"].split(" ")
+
+        index = 0
+        if self.args[-1] == "nogui":
+            index = -1
+        if self.args[-4:][-4:] == ".jar":
+            self.args[-4:] = "%s/%s" % (self.args[-4:], self.serverpath)
+        else:
+            self.log.error("Could not locate server jar name in command (should be the last argument "
+                           "or just before a last argument of 'nogui')")
         self.api = API(wrapper, "Server", internal=True)
         self.backups = Backups(wrapper)
 
@@ -74,12 +84,8 @@ class MCServer:
         self.properties = {}
         # self.reloadproperties()  This will be done on server start
 
-        self.api.registerEvent("irc.message", self.onchannelmessage)
-        self.api.registerEvent("irc.action", self.onchannelaction)
-        self.api.registerEvent("irc.join", self.onchanneljoin)
-        self.api.registerEvent("irc.part", self.onchannelpart)
-        self.api.registerEvent("irc.quit", self.onchannelquit)
-        self.api.registerEvent("timer.second", self.eachsecond)
+        if self.config["General"]["timed-reboot"] or self.config["Web"]["web-enabled"]:  # don't reg. an unused event
+            self.api.registerEvent("timer.second", self.eachsecond)
 
     def init(self):
         """
@@ -154,15 +160,15 @@ class MCServer:
         self.console("stop")
 
     def accepteula(self):
-        if os.path.isfile("eula.txt"):
+        if os.path.isfile("%s/eula.txt" % self.serverpath):
             self.log.debug("Checking EULA agreement...")
-            with open("eula.txt", "r") as f:
+            with open("%s/eula.txt" % self.serverpath, "r") as f:
                 eula = f.read()
 
             if "false" in eula:
                 # if forced, should be at info level since acceptance is a legal matter.
                 self.log.warning("EULA agreement was not accepted, accepting on your behalf...")
-                with open("eula.txt", "w") as f:
+                with open("%s/eula.txt" % self.serverpath, "w") as f:
                     f.write(eula.replace("false", "true"))
 
             self.log.debug("EULA agreement has been accepted.")
@@ -238,16 +244,15 @@ class MCServer:
             if self.config["General"]["pre-1.7-mode"]:
                 self.console("say %s" % self.chattocolorcodes(message))
             else:
-                self.console("tellraw @a %s" % json.dumps(message))
+                self.console("tellraw @a %s" % json.dumps(message, encoding=self.encoding, ensure_ascii=False))
         else:
             if self.config["General"]["pre-1.7-mode"]:
                 self.console("say %s" %
-                             self.chattocolorcodes(json.loads(processcolorcodes(message)).decode('utf-8')))
+                             self.chattocolorcodes(json.loads(processcolorcodes(message)).decode(self.encoding)))
             else:
                 self.console("tellraw @a %s" % processcolorcodes(message))
 
-    @staticmethod
-    def chattocolorcodes(jsondata):
+    def chattocolorcodes(self, jsondata):
         def getcolorcode(color):
             for code in API.colorcodes:
                 if API.colorcodes[code] == color:
@@ -269,7 +274,7 @@ class MCServer:
         if "extra" in jsondata:
             for extra in jsondata["extra"]:
                 total += handlechunk(extra)
-        return total.encode("utf8")
+        return total.encode(self.encoding)
 
     def login(self, username, eid, location):
         """
@@ -306,15 +311,15 @@ class MCServer:
 
     def reloadproperties(self):
         # Load server icon
-        if os.path.exists("server-icon.png"):
-            with open("server-icon.png", "rb") as f:
+        if os.path.exists("%s/server-icon.png" % self.serverpath):
+            with open("%s/server-icon.png" % self.serverpath, "rb") as f:
                 theicon = f.read()
                 iconencoded = base64.standard_b64encode(theicon)
                 self.serverIcon = b"data:image/png;base64," + iconencoded
         # Read server.properties and extract some information out of it
         # the PY3.5 ConfigParser seems broken.  This way was much more straightforward and works in both PY2 and PY3
-        if os.path.exists("server.properties"):
-            with open("server.properties", "r") as f:
+        if os.path.exists("%s/server.properties" % self.serverpath):
+            with open("%s/server.properties" % self.serverpath, "r") as f:
                 configfile = f.read()
             detect = configfile.split("level-name=")
             if len(detect) < 2:
@@ -511,7 +516,7 @@ class MCServer:
                     "player": self.getplayer(name), 
                     "death": getargsafter(line.split(" "), 4)
                 })
-        else:
+        else:  # pre 1.7 mode
             if len(getargs(line.split(" "), 3)) < 1:
                 return
             if getargs(line.split(" "), 3) == "Done":  # Confirmation that the server finished booting
@@ -563,66 +568,20 @@ class MCServer:
                     "player": name, 
                     "achievement": achievement
                 })
-            elif getargs(line.split(" "), 4) in deathprefixes:  # Player Death
+            elif getargs(line.split(" "), 4) in deathprefixes:  # Pre- 1.7 Player Death
                 name = self.stripspecial(getargs(line.split(" "), 3))
-                deathmessage = self.config["Death"]["death-kick-messages"][random.randrange(
-                    0, len(self.config["Death"]["death-kick-messages"]))]
-                if self.config["Death"]["kick-on-death"] and name in self.config["Death"]["users-to-kick"]:
-                    self.console("kick %s %s" % (name, deathmessage))
+                # No such config items!
+                # deathmessage = self.config["Death"]["death-kick-messages"][random.randrange(
+                #     0, len(self.config["Death"]["death-kick-messages"]))]
+                # if self.config["Death"]["kick-on-death"] and name in self.config["Death"]["users-to-kick"]:
+                #     self.console("kick %s %s" % (name, deathmessage))
                 self.wrapper.events.callevent("player.death", {
                     "player": self.getplayer(name), 
                     "death": getargsafter(line.split(" "), 4)
                 })
 
-    # Event Handlers
-
-    def messagefromchannel(self, channel, message):
-        if self.config["IRC"]["show-channel-server"]:
-            self.broadcast("&6[%s] %s" % (channel, message))
-        else:
-            self.broadcast(message)
-
-    def onchanneljoin(self, payload):
-        channel, nick = payload["channel"], payload["nick"]
-        if not self.config["IRC"]["show-irc-join-part"]:
-            return
-        self.messagefromchannel(channel, "&a%s &rjoined the channel" % nick)
-
-    def onchannelpart(self, payload):
-        channel, nick = payload["channel"], payload["nick"]
-        if not self.config["IRC"]["show-irc-join-part"]:
-            return
-        self.messagefromchannel(channel, "&a%s &rparted the channel" % nick)
-
-    def onchannelmessage(self, payload):
-        channel, nick, message = payload["channel"], payload["nick"], payload["message"]
-        final = ""
-        for i, chunk in enumerate(message.split(" ")):
-            if not i == 0:
-                final += " "
-            try:
-                if chunk[0:7] in ("http://", "https://"):
-                    final += "&b&n&@%s&@&r" % chunk
-                else:
-                    final += chunk
-            except Exception as e:
-                final += chunk
-        self.messagefromchannel(channel, "&a<%s> &r%s" % (nick, final))
-
-    def onchannelaction(self, payload):
-        channel, nick, action = payload["channel"], payload["nick"], payload["action"]
-        self.messagefromchannel(channel, "&a* %s &r%s" % (nick, action))
-
-    def onchannelquit(self, payload):
-        channel, nick, message = payload["channel"], payload["nick"], payload["message"]
-        if not self.config["IRC"]["show-irc-join-part"]:
-            return
-        self.messagefromchannel(channel, "&a%s &rquit: %s" % (nick, message))
-
+    # mcserver.py onsecond Event Handler
     def eachsecond(self, payload):
-        """
-        Called every second, and used for handling cron-like jobs
-        """
         if self.config["General"]["timed-reboot"]:
             if time.time() - self.bootTime > self.config["General"]["timed-reboot-seconds"]:
                 if self.config["General"]["timed-reboot-warning-minutes"] > 0:
@@ -643,7 +602,7 @@ class MCServer:
                     return True
                 self.lastsizepoll = time.time()
                 size = 0
-                for i in os.walk(self.worldName):
+                for i in os.walk(self.worldName):  # os.scandir not in standard library even on early py2.7.x systems
                     for f in os.listdir(i[0]):
                         size += os.path.getsize(os.path.join(i[0], f))
                 self.worldSize = size

--- a/wrapper/core/permissions.py
+++ b/wrapper/core/permissions.py
@@ -7,6 +7,7 @@ class Permissions:
 
     def __init__(self, wrapper):
         self.wrapper = wrapper
+        self.config = wrapper.config
         # self.permissions = storage.Storage("permissions")
 
     def creategroup(self, groupname):

--- a/wrapper/core/plugins.py
+++ b/wrapper/core/plugins.py
@@ -17,6 +17,7 @@ class Plugins:
     def __init__(self, wrapper):
         self.wrapper = wrapper
         self.log = wrapper.log
+        self.config = wrapper.config
         self.plugins = {}
 
     def __getitem__(self, index):

--- a/wrapper/core/scripts.py
+++ b/wrapper/core/scripts.py
@@ -31,6 +31,7 @@ class Scripts:
     def __init__(self, wrapper):
         self.api = API(wrapper, "Scripts", internal=True)
         self.wrapper = wrapper
+        self.config = wrapper.config
 
         # Register the events
         self.api.registerEvent("server.start", self._startserver)

--- a/wrapper/core/wrapper.py
+++ b/wrapper/core/wrapper.py
@@ -58,8 +58,9 @@ class Wrapper:
         self.log = logging.getLogger('Wrapper.py')
         self.storage = False
         self.configManager = Config()
-        self.configManager.loadconfig()  # Load initially for storage object
-        self.encoding = self.configManager.config["General"]["encoding"]  # This was to allow alternate encodings
+        self.configManager.loadconfig()
+        self.config = self.configManager.config  # set up config
+        self.encoding = self.config["General"]["encoding"]  # This was to allow alternate encodings
         self.javaserver = None
         self.api = None
         self.irc = None
@@ -78,16 +79,15 @@ class Wrapper:
         self.events = Events(self)
         self.permission = {}
         self.help = {}
-        self.config = {}
         self.xplayer = ConsolePlayer(self)  # future plan to expose this to api
 
         if not readline:
             self.log.warning("'readline' not imported.")
 
-        if not requests and self.configManager.config["Proxy"]["proxy-enabled"]:
+        if not requests and self.config["Proxy"]["proxy-enabled"]:
             self.log.error("You must have the requests module installed to run in proxy mode!")
             return
-        self.proxymode = self.configManager.config["Proxy"]["proxy-enabled"]
+        self.proxymode = self.config["Proxy"]["proxy-enabled"]
 
     def __del__(self):
         if self.storage:  # prevent error message on very first wrapper starts when wrapper exits after creating
@@ -98,9 +98,7 @@ class Wrapper:
 
     def start(self):
         """ wrapper should only start ONCE... old code made it restart over when only a server needed restarting"""
-        # Reload configuration each time wrapper starts in order to detect changes
-        self.configManager.loadconfig()
-        self.config = self.configManager.config
+        # Configuration is loaded on __init__ each time wrapper starts in order to detect changes
 
         signal.signal(signal.SIGINT, self.sigint)
         signal.signal(signal.SIGTERM, self.sigint)
@@ -109,13 +107,13 @@ class Wrapper:
         self._registerwrappershelp()
 
         # This is not the actual server... the MCServer class is a console wherein the server is started
-        self.javaserver = MCServer(sys.argv, self.log, self.configManager.config, self)
+        self.javaserver = MCServer(self)
         self.javaserver.init()
 
         self.plugins.loadplugins()
 
         if self.config["IRC"]["irc-enabled"]:  # this should be a plugin
-            self.irc = IRC(self.javaserver, self.config, self.log, self)
+            self.irc = IRC(self.javaserver, self.log, self)
             t = threading.Thread(target=self.irc.init, args=())
             t.daemon = True
             t.start()
@@ -130,13 +128,6 @@ class Wrapper:
                 self.log.error("Web remote could not be started because you do not have the required modules "
                                "installed: pkg_resources")
                 self.log.error("Hint: http://stackoverflow.com/questions/7446187")
-
-        # This is passed to MCserver console....
-        if len(sys.argv) < 2:
-            self.javaserver.args = self.configManager.config["General"]["command"].split(" ")
-        else:
-            # I think this allows you to run the server java command directly from the python prompt
-            self.javaserver.args = sys.argv[1:]
 
         # Console Daemon runs while not wrapper.halt (here; self.halt)
         consoledaemon = threading.Thread(target=self.parseconsoleinput, args=())
@@ -434,6 +425,7 @@ class Wrapper:
                 user_uuid_matched = useruuid  # cache for later in case multiple name changes require a uuid lookup.
 
         # try mojang  (a new player or player changed names.)
+        # requests seems to =have a builtin json() method
         r = requests.get("https://api.mojang.com/users/profiles/minecraft/%s" % username)
         if r.status_code == 200:
             useruuid = self.formatuuid(r.json()["id"])  # returns a string uuid with dashes

--- a/wrapper/management/web.py
+++ b/wrapper/management/web.py
@@ -39,7 +39,9 @@ class Web:
         self.log = logging.getLogger('Web')
         self.config = wrapper.config
         self.socket = False
-        self.data = Storage("web", self.log)
+        # self.data = Storage("web", self.log)  # Eeek! You can't pass a logger instance into a storage object!
+        self.data = Storage("web")
+
         if "keys" not in self.data:
             self.data["keys"] = []
         # if not self.config["Web"]["web-password"] == None:

--- a/wrapper/management/web.py
+++ b/wrapper/management/web.py
@@ -38,6 +38,7 @@ class Web:
         self.api = API(wrapper, "Web", internal=True)
         self.log = logging.getLogger('Web')
         self.config = wrapper.config
+        self.serverpath = self.config["General"]["server-directory"]
         self.socket = False
         # self.data = Storage("web", self.log)  # Eeek! You can't pass a logger instance into a storage object!
         self.data = Storage("web")
@@ -216,6 +217,9 @@ class WebClient:
 
     def __init__(self, wrapper, sock, addr, web):
         self.wrapper = wrapper
+        self.config = wrapper.config
+        self.serverpath = self.config["General"]["server-directory"]
+
         self.socket = sock
         self.addr = addr
         self.web = web
@@ -315,7 +319,7 @@ class WebClient:
         if action == "read_server_props":
             if not self.web.validateKey(get("key")):
                 return EOFError
-            return open("server.properties", "r").read()
+            return open("%s/server.properties" % self.serverpath, "r").read()
         if action == "save_server_props":
             if not self.web.validateKey(get("key")):
                 return EOFError
@@ -324,7 +328,7 @@ class WebClient:
                 return False
             if len(props) < 10:
                 return False
-            with open("server.properties", "w") as f:
+            with open("%s/server.properties" % self.serverpath, "w") as f:
                 f.write(props)
             return "ok"
         if action == "listdir":

--- a/wrapper/proxy/clientconnection.py
+++ b/wrapper/proxy/clientconnection.py
@@ -863,7 +863,7 @@ class Client:
                     self.disconnect("Your address is IP-banned from this server!.")
                     return False
                 if self.proxy.isuuidbanned(self.uuid.__str__()):
-                    banreason = self.wrapper.proxy.getuuidbanreason(self.uuid.__str__())
+                    banreason = self.proxy.getuuidbanreason(self.uuid.__str__())  # was self.wrapper.proxy... ?
                     self.log.info("Banned player %s tried to connect:\n %s" % (self.username, banreason))
                     self.state = ClientState.HANDSHAKE
                     self.disconnect("Banned: %s" % banreason)

--- a/wrapper/proxy/clientconnection.py
+++ b/wrapper/proxy/clientconnection.py
@@ -807,8 +807,6 @@ class Client:
                     else:
                         self.disconnect("Proxy Client Session Error (HTTP Status Code %d)" % r.status_code)
                         return False
-                    print(self.uuid.string)
-                    print(self.username)
                     currentname = self.wrapper.getusernamebyuuid(self.uuid.string)
                     if currentname:
                         if currentname != self.username:

--- a/wrapper/proxy/packet.py
+++ b/wrapper/proxy/packet.py
@@ -3,7 +3,7 @@
 # region Modules
 # ------------------------------------------------
 
-# std
+# standard
 import io
 import json
 import struct

--- a/wrapper/proxy/serverconnection.py
+++ b/wrapper/proxy/serverconnection.py
@@ -3,7 +3,7 @@
 # region Modules
 # ------------------------------------------------
 
-# std
+# standard
 import socket
 import threading
 import time

--- a/wrapper/utils/helpers.py
+++ b/wrapper/utils/helpers.py
@@ -102,19 +102,22 @@ def getargsafter(arginput, i):
     return " ".join(arginput[i:])
 
 
-def getjsonfile(filename, directory="."):
+def getjsonfile(filename, directory=".", encodedas="UTF-8"):
     """
     Args:
         filename: filename without extension
         directory: by default, wrapper script directory.
+        encodedas: the encoding
 
     Returns: a dictionary if successful. If unsuccessful; None/no data or False (if file/directory not found)
 
     """
+    if not os.path.exists(directory):
+        mkdir_p(directory)
     if os.path.exists("%s/%s.json" % (directory, filename)):
         with open("%s/%s.json" % (directory, filename), "r") as f:
             try:
-                return json.loads(f.read())
+                return json.loads(f.read(), encoding=encodedas)
             except ValueError:
                 return None
             #  Exit yielding None (no data)
@@ -131,6 +134,8 @@ def getfileaslines(filename, directory="."):
     Returns: a list if successful. If unsuccessful; None/no data or False (if file/directory not found)
 
     """
+    if not os.path.exists(directory):
+        mkdir_p(directory)
     if os.path.exists("%s/%s" % (directory, filename)):
         with open("%s/%s" % (directory, filename), "r") as f:
             try:
@@ -260,7 +265,7 @@ def processoldcolorcodes(message):
     return message
 
 
-def putjsonfile(data, filename, directory="./", indent_spaces=2, sort=False):
+def putjsonfile(data, filename, directory=".", indent_spaces=2, sort=False, encodedas="UTF-8"):
     """
     writes entire data to a json file.
     This is not for appending items to an existing file!
@@ -270,12 +275,15 @@ def putjsonfile(data, filename, directory="./", indent_spaces=2, sort=False):
     :param directory: by default, wrapper script directory.
     :param indent_spaces - indentation level. Pass None for no indents. 2 is the default.
     :param sort - whether or not to sort the records for readability
+    :param encodedas - encoding
     :returns True if successful. If unsuccessful; None = TypeError, False = file/directory not found/accessible
     """
+    if not os.path.exists(directory):
+        mkdir_p(directory)
     if os.path.exists(directory):
-        with open("%s%s.json" % (directory, filename), "w") as f:
+        with open("%s/%s.json" % (directory, filename), "w") as f:
             try:
-                f.write(json.dumps(data, indent=indent_spaces, sort_keys=sort))
+                f.write(json.dumps(data, ensure_ascii=False, indent=indent_spaces, sort_keys=sort, encoding=encodedas))
             except TypeError:
                 return None
             return True


### PR DESCRIPTION
- Fixed error in irc.py config.save() [no such method, as config is just a dictionary of config items]
- Move IRC code out of mcserver.py and put it in irc.py where it belonged.
- Only add various events if the respective modules are used (like web.py and irc.py events)
- Clean up various config assignments throughout wrapper.
- Fixed errors in web and dashboard from assigning a log instance into a storage object.
- Add encoding arguments to get and put jsonfile (utils.helpers)
- Make sure wrapper leverages get/putjsonfile everywhere it can
- Set various encoding arguments to the encoding in wrapper.properties.json
- of course, server references now point to the server-directory from wrapper.properties.json...
this includes no need to adjust the command argument.  Wrapper prepends the path to the jar file.
